### PR TITLE
Stop spawning items when no player connected

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -56,7 +56,10 @@ minetest.register_on_respawnplayer(function(player)
 	return true
 end)
 
-minetest.register_globalstep(function(dtime)
+core.register_globalstep(function(dtime)
+	if (#core.get_connected_players() < 1) then
+		return
+	end
 	timer = timer + dtime
 	clock = clock + dtime
 	if clock >= 1 then


### PR DESCRIPTION
Fixes #10 by adding an early return to stop spawning new items when no player is connected.