### PR TITLE
Use a set/map to store forbidden items

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,12 +18,20 @@ local function set_ppos(player)
 	player:set_pos(item_pos)
 end
 
+local forbidden_items = {
+	[""] = true,
+	["air"] = true,
+	["ignore"] = true,
+	["unknown"] = true,
+	["oneblock:oneblock"] = true,
+	["mcl_core:bedrock"] = true,
+}
+
 core.register_on_mods_loaded(function()
 	for item, def in pairs(core.registered_items) do
-		if item ~= "" and item ~= "air" and item ~= "ignore" and item ~= "unknown"
+		if not forbidden_items[item]
 		and def and def.description and def.description ~= ""
-		and def.groups.not_in_creative_inventory ~= 1
-		and item ~= "oneblock:oneblock" and item ~= "mcl_core:bedrock" then
+		and def.groups.not_in_creative_inventory ~= 1 then
 			table.insert(oneblock.items, item)
 		end
 	end

--- a/init.lua
+++ b/init.lua
@@ -27,6 +27,20 @@ local forbidden_items = {
 	["mcl_core:bedrock"] = true,
 	["mcl_commandblock:commandblock_off"] = true,
 	["mcl_commandblock:commandblock_on"] = true,
+	["mcl_core:light_1"] = true,
+	["mcl_core:light_2"] = true,
+	["mcl_core:light_3"] = true,
+	["mcl_core:light_4"] = true,
+	["mcl_core:light_5"] = true,
+	["mcl_core:light_6"] = true,
+	["mcl_core:light_7"] = true,
+	["mcl_core:light_8"] = true,
+	["mcl_core:light_9"] = true,
+	["mcl_core:light_10"] = true,
+	["mcl_core:light_11"] = true,
+	["mcl_core:light_12"] = true,
+	["mcl_core:light_13"] = true,
+	["mcl_core:light_14"] = true,
 }
 
 core.register_on_mods_loaded(function()

--- a/init.lua
+++ b/init.lua
@@ -25,6 +25,8 @@ local forbidden_items = {
 	["unknown"] = true,
 	["oneblock:oneblock"] = true,
 	["mcl_core:bedrock"] = true,
+	["mcl_commandblock:commandblock_off"] = true,
+	["mcl_commandblock:commandblock_on"] = true,
 }
 
 core.register_on_mods_loaded(function()


### PR DESCRIPTION
This pull request refactors the logic for filtering out forbidden items and introduces a `forbidden_items` table to centralize and simplify the exclusion logic, making it easier to maintain and extend.

Additionally, this adds the two `mcl_commandblock` nodes to the list of excluded items.